### PR TITLE
Hotfix: replace fontsize

### DIFF
--- a/src/sass/base/_normalize.scss
+++ b/src/sass/base/_normalize.scss
@@ -8,7 +8,6 @@
   font-family: "suit", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  font-size: 62.5%;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
@@ -52,4 +51,8 @@ ol {
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+html {
+  font-size: 62.5%;
 }


### PR DESCRIPTION
## 개요
:root에 들어간 폰트사이즈 속성을 html 로 옮겼습니다.

close #16 
