### PR TITLE
Hotfix: remove align-item property in #root

### DIFF
--- a/src/sass/base/_normalize.scss
+++ b/src/sass/base/_normalize.scss
@@ -38,8 +38,8 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
 
-  width: 500px;
-  min-width: 360px;
+  width: 45rem;
+  min-width: 36rem;
   min-height: 100vh;
   background: #fff;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.04);

--- a/src/sass/base/_normalize.scss
+++ b/src/sass/base/_normalize.scss
@@ -33,7 +33,6 @@ body {
 #root {
   display: flex;
   flex-direction: column;
-  align-items: center;
 
   position: relative;
   overflow-x: hidden;


### PR DESCRIPTION
## 개요
_normalize.module.scss에서 #root 선택자의 align-items 속성 제거

+ 240104 20:47 - base/_normalize.module.scss max-width 값 500px -> 45rem

## 스크린샷
  
## 주요 내용

## 고민한 점, 질문거리
