### PR TITLE
Feat: add list slide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,7 +2069,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
-
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.11",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
@@ -2422,7 +2421,6 @@
         "node": ">=12"
       }
     },
-
     "node_modules/@esbuild/win32-x64": {
       "version": "0.19.11",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
@@ -3246,7 +3244,6 @@
         }
       }
     },
-
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.3.tgz",
@@ -3403,7 +3400,6 @@
         "win32"
       ]
     },
-
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.3.tgz",
@@ -3730,7 +3726,6 @@
         }
       }
     },
-
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.3.102",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.102.tgz",
@@ -3875,7 +3870,6 @@
         "node": ">=10"
       }
     },
-
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.3.102",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.102.tgz",
@@ -5909,17 +5903,6 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.622",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.622.tgz",
@@ -6677,7 +6660,6 @@
       "version": "10.17.8",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.17.8.tgz",
       "integrity": "sha512-Flmw+iVuE3xZGGCF+Oy45RxYuNot0aUg9HngeLf6EdzhC517yV7Kt/dqeazo1drr0xu/PCXEINDc2N96UzlGeQ==",
-
       "dependencies": {
         "tslib": "^2.4.0"
       },

--- a/src/components/Home/RecommendedItemList/RecommendedItemList.module.scss
+++ b/src/components/Home/RecommendedItemList/RecommendedItemList.module.scss
@@ -1,10 +1,10 @@
 @use "@/sass" as *;
 
 .container {
-  display: flex;
-  gap: 16px;
+  @include slide_button_container;
 
-  padding: 0 20px;
-
-  overflow-x: scroll;
+  .slide_box {
+    @include slide_list_container;
+    gap: 16px;
+  }
 }

--- a/src/components/Home/RecommendedItemList/RecommendedItemList.tsx
+++ b/src/components/Home/RecommendedItemList/RecommendedItemList.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 
 import styles from "./RecommendedItemList.module.scss";
 
+import useComponentSize from "@/hooks/useComponetSize";
+
+import SlideButton from "@/components/SlideButton/SlideButton";
+
 import { getData } from "@/mocks/handlers/home";
 
 import RecommendedItem from "./RecommendedItem/RecommendedItem";
@@ -14,6 +18,8 @@ interface PropsType {
 
 function RecommendedItemList(apiNum: PropsType) {
   const [data, setData] = useState<RecommendedItemDataType[]>();
+  const [slideLocation, setSlideLocation] = useState<number>(0);
+  const [componentRef, size] = useComponentSize();
 
   useEffect(() => {
     getData<RecommendedItemDataType[] | undefined>(
@@ -24,10 +30,35 @@ function RecommendedItemList(apiNum: PropsType) {
 
   return (
     <div className={styles.container}>
-      {data &&
-        data.map((data, i) => (
-          <RecommendedItem data={data} key={data.title + i} />
-        ))}
+      {data && (
+        <SlideButton
+          // ref의 left값 state
+          slideLocation={slideLocation}
+          // left값 setState
+          setSlideLocation={setSlideLocation}
+          // 리스트 목록 아이템의 width
+          itemWidth={144}
+          // 리스트의 갭
+          flexGap={16}
+          // 아이템 갯수
+          itemNumber={data.length}
+          // 목록 전체 넓이
+          slideSize={size}
+        />
+      )}
+      <div
+        className={styles.slide_box}
+        ref={componentRef}
+        style={{
+          overflow: size.width < 450 ? "scroll" : "visible",
+          left: slideLocation + "px",
+        }}
+      >
+        {data &&
+          data.map((data, i) => (
+            <RecommendedItem data={data} key={data.title + i} />
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Home/RecommendedLocationList/RecommendedLocationList.module.scss
+++ b/src/components/Home/RecommendedLocationList/RecommendedLocationList.module.scss
@@ -1,10 +1,10 @@
 @use "@/sass" as *;
 
 .container {
-  display: flex;
-  gap: 8px;
+  @include slide_button_container;
 
-  padding: 0 20px;
-
-  overflow-x: scroll;
+  .slide_box {
+    @include slide_list_container;
+    gap: 8px;
+  }
 }

--- a/src/components/Home/RecommendedLocationList/RecommendedLocationList.tsx
+++ b/src/components/Home/RecommendedLocationList/RecommendedLocationList.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 
 import styles from "./RecommendedLocationList.module.scss";
 
+import useComponentSize from "@/hooks/useComponetSize";
+
+import SlideButton from "@/components/SlideButton/SlideButton";
+
 import { getData } from "@/mocks/handlers/home";
 
 import RecommendedLocation from "./RecommendedLocation/RecommendedLocation";
@@ -10,6 +14,8 @@ import { LocationDataType } from "@/types/home";
 
 function RecommendedLocationList() {
   const [data, setData] = useState<LocationDataType[]>();
+  const [slideLocation, setSlideLocation] = useState<number>(0);
+  const [componentRef, size] = useComponentSize();
 
   useEffect(() => {
     getData<LocationDataType[] | undefined>(
@@ -20,10 +26,29 @@ function RecommendedLocationList() {
 
   return (
     <div className={styles.container}>
-      {data &&
-        data.map((data, i) => (
-          <RecommendedLocation data={data} key={data.location + i} />
-        ))}
+      {data && (
+        <SlideButton
+          slideLocation={slideLocation}
+          setSlideLocation={setSlideLocation}
+          itemWidth={122}
+          flexGap={8}
+          itemNumber={data.length}
+          slideSize={size}
+        />
+      )}
+      <div
+        className={styles.slide_box}
+        ref={componentRef}
+        style={{
+          overflow: size.width < 450 ? "scroll" : "visible",
+          left: slideLocation + "px",
+        }}
+      >
+        {data &&
+          data.map((data, i) => (
+            <RecommendedLocation data={data} key={data.location + i} />
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Home/TabBar/TabBar.tsx
+++ b/src/components/Home/TabBar/TabBar.tsx
@@ -11,7 +11,9 @@ function TabBar() {
         <Link to="/search">
           <IoSearchSharp />
         </Link>
-        <AiOutlineBell />
+        <Link to="/alarm">
+          <AiOutlineBell />
+        </Link>
       </div>
     </div>
   );

--- a/src/components/Home/TripSpaceAtHome/TripSpaceAtHome.module.scss
+++ b/src/components/Home/TripSpaceAtHome/TripSpaceAtHome.module.scss
@@ -1,10 +1,10 @@
 @use "@/sass" as *;
 
 .container {
-  display: flex;
-  gap: 8px;
+  @include slide_button_container;
 
-  padding: 0 20px;
-
-  overflow-x: scroll;
+  .slide_box {
+    @include slide_list_container;
+    gap: 8px;
+  }
 }

--- a/src/components/Home/TripSpaceAtHome/TripSpaceAtHome.tsx
+++ b/src/components/Home/TripSpaceAtHome/TripSpaceAtHome.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 
 import styles from "./TripSpaceAtHome.module.scss";
 
+import useComponentSize from "@/hooks/useComponetSize";
+
+import SlideButton from "@/components/SlideButton/SlideButton";
+
 import { getData } from "@/mocks/handlers/home";
 
 import TripSpaceItem from "./TripSpaceItem/TripSpaceItem";
@@ -10,6 +14,8 @@ import { TripSpaceDataType } from "@/types/home";
 
 function TripSpaceAtHome() {
   const [data, setData] = useState<TripSpaceDataType[]>();
+  const [slideLocation, setSlideLocation] = useState<number>(0);
+  const [componentRef, size] = useComponentSize();
 
   const dataNull = {
     tripTitle: "아직 여행 일정이 없어요",
@@ -24,13 +30,32 @@ function TripSpaceAtHome() {
 
   return (
     <div className={styles.container}>
-      {data ? (
-        data.map((data, i) => (
-          <TripSpaceItem data={data} key={data.tripTitle + i} />
-        ))
-      ) : (
-        <TripSpaceItem data={dataNull} key={dataNull.tripTitle} />
+      {data && (
+        <SlideButton
+          slideLocation={slideLocation}
+          setSlideLocation={setSlideLocation}
+          itemWidth={323}
+          flexGap={8}
+          itemNumber={data.length}
+          slideSize={size}
+        />
       )}
+      <div
+        className={styles.slide_box}
+        ref={componentRef}
+        style={{
+          overflow: size.width < 450 ? "scroll" : "visible",
+          left: slideLocation + "px",
+        }}
+      >
+        {data ? (
+          data.map((data, i) => (
+            <TripSpaceItem data={data} key={data.tripTitle + i} />
+          ))
+        ) : (
+          <TripSpaceItem data={dataNull} key={dataNull.tripTitle} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Home/TripSpaceAtHome/TripSpaceItem/TripSpaceItem.tsx
+++ b/src/components/Home/TripSpaceAtHome/TripSpaceItem/TripSpaceItem.tsx
@@ -1,4 +1,5 @@
 import { MdArrowForwardIos } from "react-icons/md";
+import { Link } from "react-router-dom";
 
 import styles from "./TripSpaceItem.module.scss";
 
@@ -11,7 +12,7 @@ interface PropsData {
 function TripSpaceItem(data: PropsData) {
   const imageAlt = `${data.data.tripTitle}의 사진`;
   return (
-    <div className={styles.container}>
+    <Link to="/carryout" className={styles.container}>
       <div className={styles.img_box}>
         <img
           className={styles.trip_img}
@@ -30,7 +31,7 @@ function TripSpaceItem(data: PropsData) {
           <MdArrowForwardIos />
         </div>
       )}
-    </div>
+    </Link>
   );
 }
 

--- a/src/components/Home/VoteAtHome/VoteCard/CardHaveVote/CardHaveVote.module.scss
+++ b/src/components/Home/VoteAtHome/VoteCard/CardHaveVote/CardHaveVote.module.scss
@@ -1,80 +1,77 @@
 @use "@/sass" as *;
 
-.card_have_vote {
-  width: 100%;
+.container {
+  @include slide_button_container;
+  .slide_box {
+    @include slide_list_container;
+    gap: 8px;
 
-  display: flex;
-  gap: 8px;
+    .vote_box {
+      min-width: 30.8rem;
+      min-height: 16.4rem;
 
-  overflow-x: scroll;
+      background: linear-gradient(
+        119deg,
+        #62aaff 35.27%,
+        rgba(98, 170, 255, 0.3) 142.38%
+      );
 
-  padding: 0 20px;
+      border-radius: 1.6rem;
 
-  .vote_box {
-    min-width: 30.8rem;
-    min-height: 16.4rem;
+      box-sizing: border-box;
 
-    background: linear-gradient(
-      119deg,
-      #62aaff 35.27%,
-      rgba(98, 170, 255, 0.3) 142.38%
-    );
-
-    border-radius: 1.6rem;
-
-    box-sizing: border-box;
-
-    .contents {
-      height: 100%;
-
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-
-      padding: 24px;
-
-      .text_box {
-        width: 100%;
+      .contents {
+        height: 100%;
 
         display: flex;
         flex-direction: column;
-        gap: 4px;
+        justify-content: space-between;
 
-        .vote_title {
+        padding: 24px;
+
+        .text_box {
           width: 100%;
 
           display: flex;
-          align-items: center;
-          gap: 8px;
+          flex-direction: column;
+          gap: 4px;
 
-          @include typography(titleMedium);
-          .date {
-            @include typography(captionSmall);
+          .vote_title {
+            width: 100%;
+
+            display: flex;
+            align-items: center;
+            gap: 8px;
+
+            @include typography(titleMedium);
+            .date {
+              @include typography(captionSmall);
+            }
+          }
+          .discussion {
+            width: 100%;
+
+            display: flex;
+            align-items: center;
+            gap: 8px;
+
+            @include typography(titleSmall);
+
+            .profile {
+              width: 3.2rem;
+              height: 3.2rem;
+
+              border: 1px solid $neutral0;
+              border-radius: 3.2rem;
+            }
           }
         }
-        .discussion {
+        .button_box {
           width: 100%;
 
           display: flex;
-          align-items: center;
-          gap: 8px;
-
-          @include typography(titleSmall);
-
-          .profile {
-            width: 3.2rem;
-            height: 3.2rem;
-
-            border: 1px solid $neutral0;
-            border-radius: 3.2rem;
-          }
+          justify-content: flex-end;
         }
-      }
-      .button_box {
-        width: 100%;
-
-        display: flex;
-        justify-content: flex-end;
       }
     }
   }

--- a/src/components/Home/VoteAtHome/VoteCard/CardHaveVote/CardHaveVote.tsx
+++ b/src/components/Home/VoteAtHome/VoteCard/CardHaveVote/CardHaveVote.tsx
@@ -1,7 +1,12 @@
+import { useState } from "react";
 import { MdArrowForwardIos } from "react-icons/md";
 import { Link } from "react-router-dom";
 
 import styles from "./CardHaveVote.module.scss";
+
+import useComponentSize from "@/hooks/useComponetSize";
+
+import SlideButton from "@/components/SlideButton/SlideButton";
 
 import { VoteDataType } from "@/types/home";
 
@@ -10,40 +15,59 @@ interface PropsType {
 }
 
 function CardHaveVote(data: PropsType) {
+  const [slideLocation, setSlideLocation] = useState<number>(0);
+  const [componentRef, size] = useComponentSize();
   return (
-    <div className={styles.card_have_vote}>
-      {data &&
-        data.data.map((data, i) => {
-          const imageAlt = `${data.title}의 사진`;
-          return (
-            <div className={styles.vote_box} key={data.profile + i}>
-              <div className={styles.contents}>
-                <div className={styles.text_box}>
-                  <p className={styles.vote_title}>
-                    <span>{data.title}</span>
-                    <span className={styles.date}>{data.date}</span>
-                  </p>
-                  <p className={styles.discussion}>
-                    <img
-                      className={styles.profile}
-                      src={data.profile}
-                      alt={imageAlt}
-                    ></img>
-                    <span>{data.discussion}</span>
-                  </p>
-                </div>
-                <Link to={data.voteURL} className={styles.button_box}>
-                  <button>
-                    투표하기
-                    <p>
-                      <MdArrowForwardIos />
+    <div className={styles.container}>
+      <SlideButton
+        slideLocation={slideLocation}
+        setSlideLocation={setSlideLocation}
+        itemWidth={308}
+        flexGap={8}
+        itemNumber={data.data.length}
+        slideSize={size}
+      />
+      <div
+        className={styles.slide_box}
+        ref={componentRef}
+        style={{
+          overflow: size.width < 450 ? "scroll" : "visible",
+          left: slideLocation + "px",
+        }}
+      >
+        {data &&
+          data.data.map((data, i) => {
+            const imageAlt = `${data.title}의 사진`;
+            return (
+              <div className={styles.vote_box} key={data.profile + i}>
+                <div className={styles.contents}>
+                  <div className={styles.text_box}>
+                    <p className={styles.vote_title}>
+                      <span>{data.title}</span>
+                      <span className={styles.date}>{data.date}</span>
                     </p>
-                  </button>
-                </Link>
+                    <p className={styles.discussion}>
+                      <img
+                        className={styles.profile}
+                        src={data.profile}
+                        alt={imageAlt}
+                      ></img>
+                      <span>{data.discussion}</span>
+                    </p>
+                  </div>
+                  <Link to={data.voteURL} className={styles.button_box}>
+                    <button>
+                      투표하기
+                      <p>
+                        <MdArrowForwardIos />
+                      </p>
+                    </button>
+                  </Link>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+      </div>
     </div>
   );
 }

--- a/src/components/Home/VoteAtHome/VoteCard/CardNull/CardNull.module.scss
+++ b/src/components/Home/VoteAtHome/VoteCard/CardNull/CardNull.module.scss
@@ -13,8 +13,6 @@
     justify-content: space-between;
     align-items: center;
 
-    padding: 33px 24px;
-
     background: linear-gradient(
       119deg,
       #62aaff 35.27%,

--- a/src/components/Home/VoteAtHome/VoteCard/CardNull/CardNull.tsx
+++ b/src/components/Home/VoteAtHome/VoteCard/CardNull/CardNull.tsx
@@ -3,10 +3,16 @@ import { Link } from "react-router-dom";
 
 import styles from "./CardNull.module.scss";
 
+import useComponentSize from "@/hooks/useComponetSize";
+
 function CardNull() {
+  const [componentRef, size] = useComponentSize();
+  const responsivePadding = size.width - 360 <= 0 ? 0 : size.width - 360;
+  const contentsPadding = `32.5px ${responsivePadding / 5 + 24}px`;
+
   return (
-    <div className={styles.vote_box}>
-      <div className={styles.contents}>
+    <div className={styles.vote_box} ref={componentRef}>
+      <div className={styles.contents} style={{ padding: contentsPadding }}>
         <div className={styles.left}>
           <p className={styles.text}>
             친구들과 함께

--- a/src/components/SlideButton/LeftButton/LeftButton.module.scss
+++ b/src/components/SlideButton/LeftButton/LeftButton.module.scss
@@ -1,0 +1,14 @@
+@use "@/sass" as *;
+
+.container {
+  left: 10px;
+
+  transform: translate(10px, -50%);
+
+  &__icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/src/components/SlideButton/LeftButton/LeftButton.tsx
+++ b/src/components/SlideButton/LeftButton/LeftButton.tsx
@@ -1,0 +1,32 @@
+import { MdArrowBackIosNew } from "react-icons/md";
+
+import styles from "./LeftButton.module.scss";
+
+import { LeftButtonPropsType } from "@/types/home";
+
+function LeftButton({
+  slideLocation,
+  setSlideLocation,
+  itemWidth,
+  flexGap,
+}: LeftButtonPropsType) {
+  function handleButton() {
+    if (-itemWidth < slideLocation) {
+      setSlideLocation(0);
+    } else {
+      setSlideLocation(slideLocation + itemWidth + flexGap);
+    }
+  }
+
+  return (
+    <button
+      className={styles.container}
+      style={{ display: slideLocation === 0 ? "none" : "block" }}
+      onClick={handleButton}
+    >
+      <MdArrowBackIosNew className={styles.container__icon} />
+    </button>
+  );
+}
+
+export default LeftButton;

--- a/src/components/SlideButton/RightButton/RightButton.module.scss
+++ b/src/components/SlideButton/RightButton/RightButton.module.scss
@@ -1,0 +1,14 @@
+@use "@/sass" as *;
+
+.container {
+  right: 10px;
+
+  transform: translate(-10px, -50%);
+
+  &__icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/src/components/SlideButton/RightButton/RightButton.tsx
+++ b/src/components/SlideButton/RightButton/RightButton.tsx
@@ -1,0 +1,43 @@
+import { MdArrowForwardIos } from "react-icons/md";
+
+import styles from "./RightButton.module.scss";
+
+import { SlideButtonPropsType } from "@/types/home";
+
+function RightButton({
+  slideLocation,
+  setSlideLocation,
+  itemWidth,
+  itemNumber,
+  slideSize,
+  flexGap,
+}: SlideButtonPropsType) {
+  const moveRight = slideLocation - itemWidth - flexGap;
+  const moveEnd =
+    -itemWidth * itemNumber - flexGap * (itemNumber - 1) - 40 + slideSize.width;
+
+  function handleButton() {
+    if (moveRight <= moveEnd) {
+      setSlideLocation(moveEnd);
+    } else {
+      setSlideLocation(moveRight);
+    }
+  }
+  return (
+    <button
+      className={styles.container}
+      style={{
+        display:
+          -slideLocation >=
+          itemWidth * itemNumber + flexGap * (itemNumber - 1) - slideSize.width
+            ? "none"
+            : "block",
+      }}
+      onClick={handleButton}
+    >
+      <MdArrowForwardIos className={styles.container__icon} />
+    </button>
+  );
+}
+
+export default RightButton;

--- a/src/components/SlideButton/SlideButton.module.scss
+++ b/src/components/SlideButton/SlideButton.module.scss
@@ -1,0 +1,34 @@
+@use "@/sass" as *;
+
+.container {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  color: $neutral900;
+
+  button {
+    position: absolute;
+    top: 50%;
+
+    max-width: 4rem;
+    width: 4rem;
+    max-height: 4rem;
+    height: 4rem;
+    border-radius: 2rem;
+
+    background-color: $neutral0;
+    box-shadow: $shadow200;
+
+    @include typography(button);
+
+    transition: 0.3s all;
+
+    z-index: 10;
+
+    opacity: 0;
+  }
+}

--- a/src/components/SlideButton/SlideButton.tsx
+++ b/src/components/SlideButton/SlideButton.tsx
@@ -1,0 +1,39 @@
+import styles from "./SlideButton.module.scss";
+
+import LeftButton from "./LeftButton/LeftButton";
+import RightButton from "./RightButton/RightButton";
+
+import { SlideButtonPropsType } from "@/types/home";
+
+function SlideButton({
+  slideLocation,
+  setSlideLocation,
+  itemWidth,
+  itemNumber,
+  slideSize,
+  flexGap,
+}: SlideButtonPropsType) {
+  return (
+    <div
+      className={styles.container}
+      style={{ display: slideSize.width < 450 ? "none" : "block" }}
+    >
+      <LeftButton
+        slideLocation={slideLocation}
+        setSlideLocation={setSlideLocation}
+        itemWidth={itemWidth}
+        flexGap={flexGap}
+      />
+      <RightButton
+        slideLocation={slideLocation}
+        setSlideLocation={setSlideLocation}
+        itemWidth={itemWidth}
+        flexGap={flexGap}
+        itemNumber={itemNumber}
+        slideSize={slideSize}
+      />
+    </div>
+  );
+}
+
+export default SlideButton;

--- a/src/mocks/handlers/home.ts
+++ b/src/mocks/handlers/home.ts
@@ -40,8 +40,80 @@ const recommendedItem = [
       reviewNumber: "484",
       id: "1",
     },
+    {
+      title: "호텔 loft",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "제주",
+      score: "4.4",
+      reviewNumber: "484",
+      id: "1",
+    },
+    {
+      title: "호텔 loft",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "제주",
+      score: "4.4",
+      reviewNumber: "484",
+      id: "1",
+    },
+    {
+      title: "호텔 loft",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "제주",
+      score: "4.4",
+      reviewNumber: "484",
+      id: "1",
+    },
+    {
+      title: "호텔 loft",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "제주",
+      score: "4.4",
+      reviewNumber: "484",
+      id: "1",
+    },
+    {
+      title: "호텔 loft",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "제주",
+      score: "4.4",
+      reviewNumber: "484",
+      id: "1",
+    },
   ],
   [
+    {
+      title: "호텔 lee",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "서울",
+      score: "4.8",
+      reviewNumber: "184",
+      id: "1",
+    },
+    {
+      title: "호텔 lee",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "서울",
+      score: "4.8",
+      reviewNumber: "184",
+      id: "1",
+    },
+    {
+      title: "호텔 lee",
+      imageURL:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+      location: "서울",
+      score: "4.8",
+      reviewNumber: "184",
+      id: "1",
+    },
     {
       title: "호텔 lee",
       imageURL:
@@ -168,7 +240,7 @@ export const home = [
     });
   }),
   http.get("/api/home/vote", () => {
-    return HttpResponse.json(userVoteData, {
+    return HttpResponse.json(undefined, {
       status: 200,
     });
   }),

--- a/src/mocks/handlers/home.ts
+++ b/src/mocks/handlers/home.ts
@@ -182,21 +182,21 @@ const userVoteData = [
     date: "1.17-1.19",
     profile: "https://avatars.githubusercontent.com/u/154430298?s=48&v=4",
     discussion: "첫째 날 카페 어디갈래?",
-    voteURL: "/vote",
+    voteURL: "/voteDetail",
   },
   {
     title: "부산, 여수 여행",
     date: "1.17-1.19",
     profile: "https://avatars.githubusercontent.com/u/154430298?s=48&v=4",
     discussion: "둘째 날 카페 어디갈래?",
-    voteURL: "/vote",
+    voteURL: "/voteDetail",
   },
   {
     title: "부산, 여수 여행",
     date: "1.17-1.19",
     profile: "https://avatars.githubusercontent.com/u/154430298?s=48&v=4",
     discussion: "셋째 날 카페 어디갈래?",
-    voteURL: "/vote",
+    voteURL: "/voteDetail",
   },
 ];
 const tripSpaceData = [
@@ -240,7 +240,7 @@ export const home = [
     });
   }),
   http.get("/api/home/vote", () => {
-    return HttpResponse.json(undefined, {
+    return HttpResponse.json(userVoteData, {
       status: 200,
     });
   }),

--- a/src/sass/abstracts/_mixin.scss
+++ b/src/sass/abstracts/_mixin.scss
@@ -17,3 +17,23 @@
   clip: rect(0, 0, 0, 0);
   clip-path: polygon(0 0, 0 0, 0 0);
 }
+
+@mixin slide_button_container {
+  position: relative;
+
+  &:hover {
+    button {
+      opacity: 1;
+    }
+  }
+}
+
+@mixin slide_list_container {
+  position: relative;
+
+  display: flex;
+
+  padding: 0 20px;
+
+  transition: all 0.5s;
+}

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -26,3 +26,20 @@ export interface TripSpaceDataType {
   tripImg: string;
   dDay: string | undefined;
 }
+
+export interface LeftButtonPropsType {
+  slideLocation: number;
+  setSlideLocation: React.Dispatch<React.SetStateAction<number>>;
+  itemWidth: number;
+  flexGap: number;
+}
+
+interface ComponentSize {
+  width: number;
+  height: number;
+}
+
+export interface SlideButtonPropsType extends LeftButtonPropsType {
+  slideSize: ComponentSize;
+  itemNumber: number;
+}


### PR DESCRIPTION
## 개요
홈페이지의 목록들을 넘길 수 있는 슬라이드 기능 구현
close #33 

## 스크린샷
<!---- 권장 -->
![슬라이드 적용](https://github.com/Strong-Potato/TripVote-FE/assets/121215024/d4b54578-70a2-4049-a393-1834234b8f98)

## 주요 내용

- [x] 슬라이드 기능 구현
- [x] 진행 중인 투표가 없을 때 나오는 카드 반응형 패딩 적용
- [x] 각 페이지 url 연결

## 고민한 점, 질문거리
슬라이드 사용하실 분들이 계실까 싶어서 사용 방법 공유합니다.

<table>
  <tr>
    <td><img src="https://github.com/Strong-Potato/TripVote-FE/assets/121215024/5dd0db92-bbd1-410a-81ad-82c7e35d4e98" alt="이미지1의_대체_텍스트" width="400" ></td>
    <td><img src="https://github.com/Strong-Potato/TripVote-FE/assets/121215024/4246d9fa-56c9-4d6b-b290-1592b014a167" alt="이미지2의_대체_텍스트" width="400"></td>
  </tr>
</table>

슬라이드 시킬 리스트를 div로 감싸주고(스크린샷 기준 slide_box)<br> 그 밖을 한번 더 div로 감싸줍니다(스크린샷 기준 container)<br> container에 SlideButton 컴포넌트를 data&& 처리하여 불러와주시고<br>정민님이 만들어주신 useComponentSize()훅을 사용하여 slide_box에 ref를 지정하여 사용해주시면 됩니다!
아 slide_box의 인라인 스타일도 반드시 추가해주세요!!!
<br>스타일의 경우 스크린샷을 참고해주시고 gap만 바꿔서 사용하시면 됩니다!!

ps.components/Home/RecommendedItemList에 방문하시면 예시 코드를 보실 수 있습니다 ㅎㅎ
