### PR TITLE
Feat: create region select page

### DIFF
--- a/src/chakra/chakraCustomTheme.ts
+++ b/src/chakra/chakraCustomTheme.ts
@@ -2,6 +2,7 @@ import { extendTheme } from "@chakra-ui/react";
 
 import { avatarTheme } from "./avatarCustom";
 import { tabsTheme } from "./tabsCustom";
+import { tagTheme } from "./tagCustom";
 
 export const customTheme = extendTheme({
   styles: {
@@ -212,6 +213,7 @@ export const customTheme = extendTheme({
   components: {
     Avatar: avatarTheme,
     Tabs: tabsTheme,
+    Tag: tagTheme,
 
     Button: {
       baseStyle: {

--- a/src/chakra/tagCustom.ts
+++ b/src/chakra/tagCustom.ts
@@ -1,0 +1,37 @@
+import { tagAnatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(tagAnatomy.keys);
+
+const regionTag = definePartsStyle({
+  container: {
+    bg: "neutral.0",
+    color: "neutral.800",
+    borderRadius: "48px",
+    border: "1px solid #cdcfd0",
+    p: "8px 8px 8px 16px",
+    mr: "8px",
+    gap: "8px",
+    flex: "0 0 auto",
+    whiteSpace: "nowrap",
+    variant: "solid",
+  },
+  label: {
+    fontSize: "button",
+    fontWeight: "button",
+    lineHeight: "button",
+    color: "neutral.800",
+  },
+  closeButton: {
+    w: "1.6rem",
+    h: "1.6rem",
+    m: 0,
+  },
+});
+
+export const tagTheme = defineMultiStyleConfig({
+  variants: {
+    region: regionTag,
+  },
+});

--- a/src/components/TripSpace/CalendarModal/CalendarModal.module.scss
+++ b/src/components/TripSpace/CalendarModal/CalendarModal.module.scss
@@ -1,24 +1,6 @@
 @use "@/sass" as *;
 
 .Container {
-  header {
-    background-color: $neutral0;
-    width: 100%;
-    max-width: 45rem;
-    position: fixed;
-    top: 0;
-    z-index: 2;
-
-    nav {
-      padding: 16px 20px;
-    }
-
-    h1 {
-      @include typography(headline);
-      padding: 8px 20px;
-    }
-  }
-
   .calendarContainer {
     margin-top: 10.2rem;
     margin-bottom: 14rem;

--- a/src/components/TripSpace/CalendarModal/CalendarModal.tsx
+++ b/src/components/TripSpace/CalendarModal/CalendarModal.tsx
@@ -8,8 +8,9 @@ import { BsCalendarCheck as CalendarIcon } from "react-icons/bs";
 import "react-datepicker/dist/react-datepicker.css";
 import styles from "./CalendarModal.module.scss";
 
-import BackIcon from "@/assets/back.svg?react";
 import { printDayNight } from "@/utils/printDayNight";
+
+import SelectHeader from "../SelectHeader/SelectHeader";
 
 function CalendarModal() {
   registerLocale("ko", ko);
@@ -41,12 +42,7 @@ function CalendarModal() {
 
   return (
     <div className={styles.Container}>
-      <header>
-        <nav>
-          <BackIcon />
-        </nav>
-        <h1>언제 떠나시나요?</h1>
-      </header>
+      <SelectHeader title="언제 떠나시나요?" />
       <div className={styles.calendarContainer}>
         {/* FIXME : date picker 수정사항
           1. 달력 첫째주에 지난 달 날짜 보이도록

--- a/src/components/TripSpace/NoSearchResult/NoSearchResult.module.scss
+++ b/src/components/TripSpace/NoSearchResult/NoSearchResult.module.scss
@@ -1,0 +1,18 @@
+@use "@/sass" as *;
+
+.container {
+  width: 100%;
+  min-width: 36rem;
+  max-width: 45rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.6rem;
+  margin-top: 14rem;
+
+  p {
+    @include typography(subTitle);
+    color: $neutral400;
+  }
+}

--- a/src/components/TripSpace/NoSearchResult/NoSearchResult.tsx
+++ b/src/components/TripSpace/NoSearchResult/NoSearchResult.tsx
@@ -1,0 +1,14 @@
+import { TfiSearch as SearchIcon } from "react-icons/tfi";
+
+import styles from "./NoSearchResult.module.scss";
+
+function NoSearchResult() {
+  return (
+    <div className={styles.container}>
+      <SearchIcon size="5rem" color="#CDCFD0" />
+      <p>검색 결과가 없습니다.</p>
+    </div>
+  );
+}
+
+export default NoSearchResult;

--- a/src/components/TripSpace/RegionList/RegionList.module.scss
+++ b/src/components/TripSpace/RegionList/RegionList.module.scss
@@ -1,0 +1,42 @@
+@use "@/sass" as *;
+
+.container {
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  img {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 100px;
+  }
+
+  .regionInformation {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+
+    span {
+      @include typography(titleSmall);
+      color: $neutral900;
+    }
+  }
+
+  button {
+    @include typography(captionSmall);
+    border-radius: 16px;
+    width: 5.3rem;
+    height: 2.8rem;
+  }
+
+  .selectedButton {
+    background-color: $primary300;
+    color: $neutral0;
+  }
+
+  .unselectedButton {
+    background-color: $neutral100;
+    color: $neutral800;
+  }
+}

--- a/src/components/TripSpace/RegionList/RegionList.tsx
+++ b/src/components/TripSpace/RegionList/RegionList.tsx
@@ -1,0 +1,29 @@
+// RegionList.jsx
+
+import styles from "./RegionList.module.scss";
+
+interface RegionListProps {
+  name: string;
+  imageUrl: string;
+  isSelected: boolean;
+  onSelect: (regionName: string) => void;
+}
+
+function RegionList({ name, imageUrl, isSelected, onSelect }: RegionListProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.regionInformation}>
+        <img src={imageUrl} alt={name} />
+        <span>{name}</span>
+      </div>
+      <button
+        className={isSelected ? styles.selectedButton : styles.unselectedButton}
+        onClick={() => onSelect(name)}
+      >
+        {isSelected ? "선택됨" : "선택"}
+      </button>
+    </div>
+  );
+}
+
+export default RegionList;

--- a/src/components/TripSpace/RegionList/RegionList.tsx
+++ b/src/components/TripSpace/RegionList/RegionList.tsx
@@ -1,13 +1,6 @@
-// RegionList.jsx
-
 import styles from "./RegionList.module.scss";
 
-interface RegionListProps {
-  name: string;
-  imageUrl: string;
-  isSelected: boolean;
-  onSelect: (regionName: string) => void;
-}
+import { RegionListProps } from "@/types/regionSearch";
 
 function RegionList({ name, imageUrl, isSelected, onSelect }: RegionListProps) {
   return (

--- a/src/components/TripSpace/RegionSearchBox/RegionSearchBox.module.scss
+++ b/src/components/TripSpace/RegionSearchBox/RegionSearchBox.module.scss
@@ -1,0 +1,52 @@
+@use "@/sass" as *;
+
+.container {
+  padding: 0 20px;
+  position: fixed;
+  z-index: 3;
+  margin-top: 11rem;
+  width: 100%;
+  min-width: 36rem;
+  max-width: 45rem;
+  background-color: $neutral0;
+}
+
+.focusContainer {
+  padding: 0 20px;
+  position: fixed;
+  z-index: 3;
+  margin-top: 0;
+  width: 100%;
+  min-width: 36rem;
+  max-width: 45rem;
+  background-color: $neutral0;
+}
+
+.inputContainer {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 12px 8px 12px;
+
+  .inputContents {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  input {
+    @include typography(subTitle);
+    width: 100%;
+    outline: none;
+    color: $neutral900;
+
+    &::placeholder {
+      color: $neutral300;
+    }
+  }
+}
+
+.underLine {
+  height: 0.2rem;
+  background: $primary300;
+}

--- a/src/components/TripSpace/RegionSearchBox/RegionSearchBox.module.scss
+++ b/src/components/TripSpace/RegionSearchBox/RegionSearchBox.module.scss
@@ -4,7 +4,7 @@
   padding: 0 20px;
   position: fixed;
   z-index: 3;
-  margin-top: 11rem;
+  margin-top: 10.4rem;
   width: 100%;
   min-width: 36rem;
   max-width: 45rem;
@@ -20,6 +20,7 @@
   min-width: 36rem;
   max-width: 45rem;
   background-color: $neutral0;
+  transition: all 0.5s;
 }
 
 .inputContainer {

--- a/src/components/TripSpace/RegionSearchBox/RegionSearchBox.tsx
+++ b/src/components/TripSpace/RegionSearchBox/RegionSearchBox.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { TfiSearch as SearchIcon } from "react-icons/tfi";
+import { useNavigate } from "react-router-dom";
+
+import styles from "./RegionSearchBox.module.scss";
+
+import BackIcon from "@/assets/back.svg?react";
+import CloseIcon from "@/assets/close.svg?react";
+
+import { FormData, RegionSearchInputProps } from "@/types/regionSearch";
+
+function RegionSearchInput({
+  onInputChange,
+  onSearchCompletionChange,
+}: RegionSearchInputProps) {
+  const navigate = useNavigate();
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const [isSearchCompleted, setIsSearchCompleted] = useState(false);
+  const { register, handleSubmit, setValue } = useForm<FormData>({
+    mode: "onChange",
+    defaultValues: {
+      region: "",
+    },
+  });
+
+  const handleInputFocus = () => {
+    setIsInputFocused(true);
+    onInputChange(true);
+  };
+
+  const handleInputBlur = () => {
+    setIsInputFocused(false);
+    onInputChange(false);
+  };
+
+  // FIXME: 검색 클릭 핸들링 수정
+  const handleSearch = (data: FormData) => {
+    console.log("input:", data.region);
+    // TODO: 검색 로직 구현
+
+    if (data.region) {
+      setIsSearchCompleted(true);
+      onSearchCompletionChange(true);
+    }
+  };
+
+  const handleClearInput = () => {
+    setValue("region", "");
+    setIsSearchCompleted(false);
+    onSearchCompletionChange(false);
+  };
+
+  useEffect(() => {
+    console.log("포커스", isInputFocused);
+    console.log("검색완료", isSearchCompleted);
+  }, [isInputFocused, isSearchCompleted]);
+
+  return (
+    <form
+      className={
+        isInputFocused || isSearchCompleted
+          ? styles.focusContainer
+          : styles.container
+      }
+      onSubmit={handleSubmit(handleSearch)}
+    >
+      <div className={styles.inputContainer}>
+        <div className={styles.inputContents}>
+          {(isInputFocused || isSearchCompleted) && (
+            <button onClick={() => navigate(-1)}>
+              <BackIcon />
+            </button>
+          )}
+          <input
+            type="text"
+            placeholder="여행 도시를 검색해보세요."
+            onFocus={handleInputFocus}
+            {...register("region", { onBlur: handleInputBlur })}
+          />
+          {isSearchCompleted ? (
+            <button type="button" onClick={handleClearInput}>
+              <CloseIcon />
+            </button>
+          ) : (
+            <button type="submit">
+              <SearchIcon size="2.4rem" color="#23272F" />
+            </button>
+          )}
+        </div>
+      </div>
+      <div className={styles.underLine}></div>
+    </form>
+  );
+}
+
+export default RegionSearchInput;

--- a/src/components/TripSpace/RegionSearchBox/RegionSearchBox.tsx
+++ b/src/components/TripSpace/RegionSearchBox/RegionSearchBox.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { TfiSearch as SearchIcon } from "react-icons/tfi";
-import { useNavigate } from "react-router-dom";
 
 import styles from "./RegionSearchBox.module.scss";
+
+import useGoBack from "@/hooks/useGoBack";
 
 import BackIcon from "@/assets/back.svg?react";
 import CloseIcon from "@/assets/close.svg?react";
@@ -12,17 +13,18 @@ import { FormData, RegionSearchInputProps } from "@/types/regionSearch";
 
 function RegionSearchInput({
   onInputChange,
-  onSearchCompletionChange,
+  onRegionValueChange,
 }: RegionSearchInputProps) {
-  const navigate = useNavigate();
+  const goBack = useGoBack();
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isSearchCompleted, setIsSearchCompleted] = useState(false);
-  const { register, handleSubmit, setValue } = useForm<FormData>({
+  const { register, handleSubmit, setValue, watch } = useForm<FormData>({
     mode: "onChange",
     defaultValues: {
       region: "",
     },
   });
+  const regionValue = watch("region");
 
   const handleInputFocus = () => {
     setIsInputFocused(true);
@@ -41,34 +43,41 @@ function RegionSearchInput({
 
     if (data.region) {
       setIsSearchCompleted(true);
-      onSearchCompletionChange(true);
     }
   };
 
   const handleClearInput = () => {
     setValue("region", "");
     setIsSearchCompleted(false);
-    onSearchCompletionChange(false);
   };
 
   useEffect(() => {
+    onRegionValueChange(regionValue);
+  }, [regionValue, onRegionValueChange]);
+
+  useEffect(() => {
     console.log("포커스", isInputFocused);
-    console.log("검색완료", isSearchCompleted);
-  }, [isInputFocused, isSearchCompleted]);
+    console.log("입력값", regionValue);
+    console.log("result", isInputFocused || regionValue);
+  }, [isInputFocused, regionValue]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSubmit(handleSearch)();
+    }
+  };
 
   return (
     <form
       className={
-        isInputFocused || isSearchCompleted
-          ? styles.focusContainer
-          : styles.container
+        isInputFocused || regionValue ? styles.focusContainer : styles.container
       }
       onSubmit={handleSubmit(handleSearch)}
     >
       <div className={styles.inputContainer}>
         <div className={styles.inputContents}>
-          {(isInputFocused || isSearchCompleted) && (
-            <button onClick={() => navigate(-1)}>
+          {(isInputFocused || regionValue) && (
+            <button onClick={goBack}>
               <BackIcon />
             </button>
           )}
@@ -76,6 +85,7 @@ function RegionSearchInput({
             type="text"
             placeholder="여행 도시를 검색해보세요."
             onFocus={handleInputFocus}
+            onKeyDown={handleKeyDown}
             {...register("region", { onBlur: handleInputBlur })}
           />
           {isSearchCompleted ? (

--- a/src/components/TripSpace/RegionTagItem/RegionTagItem.tsx
+++ b/src/components/TripSpace/RegionTagItem/RegionTagItem.tsx
@@ -1,0 +1,16 @@
+import { Tag, TagCloseButton, TagLabel } from "@chakra-ui/react";
+
+import CloseIcon from "@/assets/close.svg?react";
+
+import { TagItemProps } from "@/types/regionSearch";
+
+const RegionTagItem = ({ label, onClose }: TagItemProps) => (
+  <Tag variant="region">
+    <TagLabel>{label}</TagLabel>
+    <button onClick={onClose}>
+      <TagCloseButton as={CloseIcon} />
+    </button>
+  </Tag>
+);
+
+export default RegionTagItem;

--- a/src/components/TripSpace/SelectHeader/SelectHeader.module.scss
+++ b/src/components/TripSpace/SelectHeader/SelectHeader.module.scss
@@ -1,0 +1,19 @@
+@use "@/sass" as *;
+
+header {
+  background-color: $neutral0;
+  width: 100%;
+  max-width: 45rem;
+  position: fixed;
+  top: 0;
+  z-index: 2;
+
+  nav {
+    padding: 16px 20px;
+  }
+
+  h1 {
+    @include typography(headline);
+    padding: 8px 20px;
+  }
+}

--- a/src/components/TripSpace/SelectHeader/SelectHeader.tsx
+++ b/src/components/TripSpace/SelectHeader/SelectHeader.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from "react-router-dom";
+
+import "./SelectHeader.module.scss";
+
+import BackIcon from "@/assets/back.svg?react";
+
+import { SelectHeaderProps } from "@/types/selectHeader";
+
+function SelectHeader({ title }: SelectHeaderProps) {
+  const navigate = useNavigate();
+
+  return (
+    <header>
+      <nav>
+        <button onClick={() => navigate(-1)}>
+          <BackIcon />
+        </button>
+      </nav>
+      <h1>{title}</h1>
+    </header>
+  );
+}
+
+export default SelectHeader;

--- a/src/pages/RegionSearch/RegionSearch.module.scss
+++ b/src/pages/RegionSearch/RegionSearch.module.scss
@@ -1,0 +1,66 @@
+@use "@/sass" as *;
+
+.container {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  .header {
+    height: 17rem;
+    background-color: $neutral0;
+    transition: all 0.5s;
+  }
+
+  .focusHeader {
+    height: 5rem;
+    background-color: $neutral0;
+    transition: all 0.5s;
+  }
+
+  .contentsContainer {
+    width: 100%;
+    min-width: 36rem;
+    max-width: 45rem;
+    height: calc(100vh - 17rem);
+    margin-top: 17rem;
+    margin-bottom: 15.5rem;
+    position: sticky;
+    top: 17rem;
+    overflow-y: auto;
+    transition: all 0.5s;
+
+    &__focus {
+      width: 100%;
+      min-width: 36rem;
+      max-width: 45rem;
+      height: calc(100vh - 5rem);
+      margin-top: 5rem;
+      margin-bottom: 15.5rem;
+      position: sticky;
+      top: 5rem;
+      overflow-y: auto;
+      transition: all 0.5s;
+    }
+  }
+
+  .regionChoiceContainer {
+    background-color: $neutral0;
+    box-shadow: $shadow200;
+    position: fixed;
+    bottom: 0px;
+    z-index: 3;
+    width: 100%;
+    min-width: 36rem;
+    max-width: 45rem;
+    height: 15.5rem;
+    padding: 24px 20px;
+    white-space: nowrap;
+
+    .tagContainer {
+      display: flex;
+      overflow-x: auto;
+    }
+  }
+}

--- a/src/pages/RegionSearch/RegionSearch.tsx
+++ b/src/pages/RegionSearch/RegionSearch.tsx
@@ -1,0 +1,161 @@
+import { Button } from "@chakra-ui/react";
+import { useState } from "react";
+
+import styles from "./RegionSearch.module.scss";
+
+import NoSearchResult from "@/components/TripSpace/NoSearchResult/NoSearchResult";
+import RegionList from "@/components/TripSpace/RegionList/RegionList";
+import RegionSearchBox from "@/components/TripSpace/RegionSearchBox/RegionSearchBox";
+import RegionTagItem from "@/components/TripSpace/RegionTagItem/RegionTagItem";
+import SelectHeader from "@/components/TripSpace/SelectHeader/SelectHeader";
+
+function RegionSearch() {
+  const regions = [
+    {
+      name: "서울",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "부산",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "대전",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "감자밭",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "감자마을",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "포테토",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "감자도리",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "고구마가",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "되고 싶어",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+    {
+      name: "꿈을 꾼다",
+      imageUrl:
+        "https://m.eejmall.com/web/product/big/201708/211_shop1_627935.jpg",
+    },
+  ];
+
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const [regionValue, setRegionValue] = useState("");
+
+  const handleInputChange = (newIsInputFocused: boolean) => {
+    setIsInputFocused(newIsInputFocused);
+  };
+
+  const handleRegionValueChange = (newRegionValue: string) => {
+    setRegionValue(newRegionValue);
+  };
+
+  const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
+  const handleRegionSelect = (regionName: string) => {
+    if (selectedRegions.includes(regionName)) {
+      setSelectedRegions((prevSelectedRegions) =>
+        prevSelectedRegions.filter((name) => name !== regionName),
+      );
+    } else {
+      if (selectedRegions.length < 4) {
+        setSelectedRegions((prevSelectedRegions) => [
+          ...prevSelectedRegions,
+          regionName,
+        ]);
+      }
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <header
+        className={
+          isInputFocused || regionValue ? styles.focusHeader : styles.header
+        }
+      >
+        {!(isInputFocused || regionValue) && (
+          <SelectHeader title="어디로 떠나세요?" />
+        )}
+        <RegionSearchBox
+          onInputChange={handleInputChange}
+          onRegionValueChange={handleRegionValueChange}
+        />
+      </header>
+      <div
+        className={
+          isInputFocused || regionValue
+            ? styles.contentsContainer__focus
+            : styles.contentsContainer
+        }
+      >
+        {regions.length ? (
+          <>
+            {regions.map((region) => (
+              <RegionList
+                key={region.name}
+                name={region.name}
+                imageUrl={region.imageUrl}
+                isSelected={selectedRegions.includes(region.name)}
+                onSelect={handleRegionSelect}
+              />
+            ))}
+          </>
+        ) : (
+          <NoSearchResult />
+        )}
+      </div>
+      <div
+        className={selectedRegions.length ? styles.regionChoiceContainer : ""}
+      >
+        <div className={styles.tagContainer}>
+          {selectedRegions.map((region) => (
+            <RegionTagItem
+              key={region}
+              label={region}
+              onClose={() =>
+                setSelectedRegions((prevSelectedRegions) =>
+                  prevSelectedRegions.filter((name) => name !== region),
+                )
+              }
+            />
+          ))}
+        </div>
+        <Button
+          isDisabled={!selectedRegions.length}
+          zIndex="3"
+          variant="CTAButton"
+        >
+          {selectedRegions.length
+            ? `${selectedRegions.length}개 선택 완료`
+            : "도시를 선택해주세요"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default RegionSearch;

--- a/src/types/regionSearch.ts
+++ b/src/types/regionSearch.ts
@@ -13,3 +13,8 @@ export interface RegionSearchInputProps {
   onInputChange: (newIsInputFocused: boolean) => void;
   onSearchCompletionChange: (newIsSearchCompleted: boolean) => void;
 }
+
+export interface TagItemProps {
+  label: string;
+  onClose: () => void;
+}

--- a/src/types/regionSearch.ts
+++ b/src/types/regionSearch.ts
@@ -4,3 +4,12 @@ export interface RegionListProps {
   isSelected: boolean;
   onSelect: (regionName: string) => void;
 }
+
+export interface FormData {
+  region: string;
+}
+
+export interface RegionSearchInputProps {
+  onInputChange: (newIsInputFocused: boolean) => void;
+  onSearchCompletionChange: (newIsSearchCompleted: boolean) => void;
+}

--- a/src/types/regionSearch.ts
+++ b/src/types/regionSearch.ts
@@ -1,0 +1,6 @@
+export interface RegionListProps {
+  name: string;
+  imageUrl: string;
+  isSelected: boolean;
+  onSelect: (regionName: string) => void;
+}

--- a/src/types/regionSearch.ts
+++ b/src/types/regionSearch.ts
@@ -11,7 +11,7 @@ export interface FormData {
 
 export interface RegionSearchInputProps {
   onInputChange: (newIsInputFocused: boolean) => void;
-  onSearchCompletionChange: (newIsSearchCompleted: boolean) => void;
+  onRegionValueChange: (regionValue: string) => void;
 }
 
 export interface TagItemProps {

--- a/src/types/selectHeader.ts
+++ b/src/types/selectHeader.ts
@@ -1,0 +1,3 @@
+export interface SelectHeaderProps {
+  title: string;
+}


### PR DESCRIPTION
## 개요
close #62 

## 스크린샷
<img width="300px" src="https://github.com/Strong-Potato/TripVote-FE/assets/63582234/81d82a2f-b48c-41e4-a7d3-6d65476685dc" />
  
## 주요 내용

- [x] 지역 검색(선택) 페이지 마크업
- [x] chakra `Tag` 커스텀
- [x] 지역 선택 시 태그 추가
- [x] 검색창 스타일 변화 적용
- [ ] 검색 필터링 적용 X (기능 추후 추가 예정)

## 고민한 점, 질문거리
<img width="250px" src="https://github.com/Strong-Potato/TripVote-FE/assets/63582234/ceca242f-68b2-4725-a6d2-930a3ca36058" />
<img width="250px" src="https://github.com/Strong-Potato/TripVote-FE/assets/63582234/7d77eabe-7696-48bc-b617-5330278ef94c" />

문제: 스타일 변경 자체는 적용되었으나, 스타일이 변경되면 **검색 버튼이 눌리지 않아 submit이 되지 않는 오류 발생** (두 번 눌러야 submit 됨)
input에 focus 됐을 때 왼쪽 -> 오른쪽처럼 검색창 위치가 변경되고 검색 버튼을 누른 후에도 오른쪽 스타일로 유지되어야 하는데, `onFocus`만으로는 정상적으로 스타일이 변경되지 않았습니다.. 
그래서 포커스, 클릭, 액티브, 검색이 완료되었는지 등 여러 이벤트와 값을 생성해서 해당 boolean 값에 따라 적용해봤는데 잘 안 돼서 고민을 오래 했습니다,,
디버깅 해봤을 때 검색 버튼 자체가 안 눌리고 있었기 때문에 검색 완료된 시점으로 스타일 분기 처리를 하면 안 될 것 같아서 포커스가 되었는지 `isInputFocused` 값과, input에 입력되고 있는 `regionValue` 값을 검사하여 **포커스 되었거나 검색어가 있을 때는 검색창이 상단에 고정되도록** 수정했더니 해결되었습니다. 
이틀 동안 해결 못 했었는데 `useForm의 watch`를 사용했더니 되는 문제였습니다,,

사담으로 조금 더 적어보자면,, useForm을 처음 써봐서 어떻게 작성해야 제대로 사용하는 건지 잘 모르겠는 이슈 때문에 더 오래 걸렸던 것 같습니다,,
그리고 사실 모바일에서는 searchable 속성 하나만 추가하면 제가 열심히 구현한 포커스 됐을 때 검색창이 위로 붙는 스타일이 ☆**자동으로**☆ 적용된다고 하더라고요^^... 
모바일에서는 자연스럽고 원래 있는 UI라 디자인이 그렇게 나온 것 같은데 웹에서는 레퍼런스가 존재하지 않아서 많이 헤맸습니다..🥲 
그래서 처음에 단순무식하게 포커스로 class명을 분기한 건데, 오래 걸리긴 했지만 해결하고 기뻐서 transition으로 자연스러움도 한 스푼 넣었습니다 하하
