### PR TITLE
Feat: create detail page map

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,6 @@ module.exports = {
     "@tanstack/eslint-plugin-query",
   ],
   rules: {
-    "@typescript-eslint/no-explicit-any": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
       "warn",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,7 @@ module.exports = {
     "@tanstack/eslint-plugin-query",
   ],
   rules: {
+    "@typescript-eslint/no-explicit-any": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
       "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.49.2",
         "react-icons": "^4.12.0",
+        "react-kakao-maps-sdk": "^1.1.24",
         "react-router-dom": "^6.21.1",
         "recoil": "^0.7.7",
         "swiper": "^11.0.5"
@@ -8977,6 +8978,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
+      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ=="
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10077,6 +10083,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.24.tgz",
+      "integrity": "sha512-leLbFwBj6zbTdDg6A9U7EwYT2oq0+2F+NHZSVTyCmmvyc4yt2zpRvUmcAt8I6h2SDUdgHbpvKAV1sZoRIxD4JQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
     },
     "node_modules/react-onclickoutside": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.49.2",
     "react-icons": "^4.12.0",
+    "react-kakao-maps-sdk": "^1.1.24",
     "react-router-dom": "^6.21.1",
     "recoil": "^0.7.7",
     "swiper": "^11.0.5"

--- a/src/components/Detail/Contents/Information/BasicInformation/BasicInformation.tsx
+++ b/src/components/Detail/Contents/Information/BasicInformation/BasicInformation.tsx
@@ -5,13 +5,13 @@ import { MdPlace } from "react-icons/md";
 
 import styles from "./BasicInformation.module.scss";
 
-import Map from "./Map/Map";
+import MapInDetail from "./MapInDetail/MapInDetail";
 
 function BasicInformation() {
   return (
     <div className={styles.container}>
       <div className={styles.container__title}>기본정보</div>
-      <Map />
+      <MapInDetail />
       <div className={styles.container__contents}>
         <div className={styles.container__contents__item}>
           <MdPlace color="#979C9E" fontSize="2.4rem" />

--- a/src/components/Detail/Contents/Information/BasicInformation/Map/Map.tsx
+++ b/src/components/Detail/Contents/Information/BasicInformation/Map/Map.tsx
@@ -1,7 +1,0 @@
-import styles from "./Map.module.scss";
-
-function Map() {
-  return <div className={styles.container}>지도</div>;
-}
-
-export default Map;

--- a/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.module.scss
+++ b/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.module.scss
@@ -1,6 +1,7 @@
 .container {
   width: 100%;
-  height: 149px;
+  // 비율 3:2 조절
+  aspect-ratio: 5 / 2;
 
   display: flex;
   justify-content: center;

--- a/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
+++ b/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { useEffect, useState } from "react";
 import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 

--- a/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
+++ b/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
@@ -1,17 +1,41 @@
+import { useEffect, useState } from "react";
 import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 
 import styles from "./MapInDetail.module.scss";
 
 import BigHomeMarker from "@/assets/homeIcons/map/house_big.svg?react";
 
+interface Coordinate {
+  lat: number;
+  lng: number;
+}
+
 // 장소 정보에 따라 마커 다르게 표시
 function MapInDetail() {
+  const [coordinate, setCoordinate] = useState<Coordinate>({
+    lat: 33.5563,
+    lng: 126.79581,
+  });
+
+  useEffect(() => {
+    const geocoder = new kakao.maps.services.Geocoder();
+
+    const callback = (result: any, status: any) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const newSearch = result[0];
+        setCoordinate({ lat: newSearch.y, lng: newSearch.x });
+      }
+    };
+
+    geocoder.addressSearch("경기도 양평군 양평읍 백안리 9", callback);
+  }, []);
+
   return (
     <Map
-      center={{ lat: 37.511666, lng: 127.533559 }}
+      center={{ lat: coordinate.lat, lng: coordinate.lng }}
       className={styles.container}
     >
-      <CustomOverlayMap position={{ lat: 37.511666, lng: 127.533559 }}>
+      <CustomOverlayMap position={{ lat: coordinate.lat, lng: coordinate.lng }}>
         <BigHomeMarker />
       </CustomOverlayMap>
     </Map>

--- a/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
+++ b/src/components/Detail/Contents/Information/BasicInformation/MapInDetail/MapInDetail.tsx
@@ -1,0 +1,21 @@
+import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
+
+import styles from "./MapInDetail.module.scss";
+
+import BigHomeMarker from "@/assets/homeIcons/map/house_big.svg?react";
+
+// 장소 정보에 따라 마커 다르게 표시
+function MapInDetail() {
+  return (
+    <Map
+      center={{ lat: 37.511666, lng: 127.533559 }}
+      className={styles.container}
+    >
+      <CustomOverlayMap position={{ lat: 37.511666, lng: 127.533559 }}>
+        <BigHomeMarker />
+      </CustomOverlayMap>
+    </Map>
+  );
+}
+
+export default MapInDetail;


### PR DESCRIPTION
## 개요
> 상세 페이지 카카오맵 추가

## 스크린샷
<img width="581" alt="image" src="https://github.com/Strong-Potato/TripVote-FE/assets/57976371/40503ede-e959-44ee-bde2-0665af3e670c">  

## 주요 내용

- [ ] 카카오맵 적용
- [ ] 주소로 좌표 검색 후 마커 찍음

## 고민한 점, 질문거리

close #102 
