### PR TITLE
Feat: add password input in withdrawal #198

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+export const authRequest = {
+  withdrawal: async (password?: string) =>
+    await axios.post(
+      '/api/members/sign-out',
+      {
+        password,
+      },
+      {withCredentials: true},
+    ),
+};

--- a/src/pages/Auth/Withdrawal/Withdrawal.module.scss
+++ b/src/pages/Auth/Withdrawal/Withdrawal.module.scss
@@ -1,4 +1,4 @@
-@use "@/sass" as *;
+@use '@/sass' as *;
 
 .container {
   color: $neutral900;
@@ -16,7 +16,7 @@
         margin-left: 4px;
         vertical-align: text-top;
 
-        background-image: url("@/assets/icons/crying_imoji.svg");
+        background-image: url('@/assets/icons/crying_imoji.svg');
         background-position: center;
         background-repeat: no-repeat;
       }
@@ -41,6 +41,36 @@
 
       & > li {
         margin-bottom: 8px;
+      }
+    }
+
+    .input {
+      width: 100%;
+      margin-top: 6px;
+      margin-bottom: 24px;
+      padding: 16px;
+      border: 1px solid $neutral200;
+      border-radius: 8px;
+
+      @include typography(bodyLarge);
+      color: $neutral900;
+
+      &:focus {
+        outline: none;
+        border-width: 1px;
+        border-color: $primary300;
+      }
+
+      &::placeholder {
+        color: $neutral400;
+      }
+
+      &.error {
+        border-color: $danger300;
+      }
+
+      &:disabled {
+        color: $neutral300;
       }
     }
   }


### PR DESCRIPTION
## 개요
withdrawal 페이지에서 자체 회원가입 유저의 경우 비밀번호를 받는 input 렌더링

## 스크린샷
  
## 주요 내용

- [x] 비밀번호 인풋 영역 생성
- [x] 회원탈퇴 api 연결 및 결과에 따른 동작 작성

## 고민한 점, 질문거리

close #198