### PR TITLE
Feat: fix split error & add toaset in modify password & add props cancel action

### DIFF
--- a/src/components/AlertModal/AlertModal.tsx
+++ b/src/components/AlertModal/AlertModal.tsx
@@ -20,7 +20,15 @@ import {AlertModalProps} from '@/types/vote';
  * 
  * 자세한 사용은 VoteMeatball.tsx 참고
  */
-const AlertModal = ({title, subText, cancelText, actionButton, isSmallSize, onClickAction}: AlertModalProps) => {
+const AlertModal = ({
+  title,
+  subText,
+  cancelText,
+  actionButton,
+  isSmallSize,
+  onClickAction,
+  onClickCancelAction,
+}: AlertModalProps) => {
   const [isModalOpen, setIsModalOpen] = useRecoilState(isModalOpenState);
 
   return (
@@ -33,7 +41,13 @@ const AlertModal = ({title, subText, cancelText, actionButton, isSmallSize, onCl
         </ModalBody>
 
         <ModalFooter>
-          <button onClick={() => setIsModalOpen(false)} className={styles.buttons__cancel}>
+          <button
+            onClick={() => {
+              setIsModalOpen(false);
+              onClickCancelAction && onClickCancelAction();
+            }}
+            className={styles.buttons__cancel}
+          >
             {cancelText ? cancelText : '취소'}
           </button>
           <button onClick={onClickAction} className={styles.buttons__action}>

--- a/src/components/Auth/ModifyPassword/ModifyPasswordForm.tsx
+++ b/src/components/Auth/ModifyPassword/ModifyPasswordForm.tsx
@@ -4,6 +4,8 @@ import {useNavigate} from 'react-router-dom';
 
 import styles from './ModifyPasswordForm.module.scss';
 
+import CustomToast from '@/components/CustomToast/CustomToast';
+
 import {authRequest} from '@/api/auth';
 
 import StepNewPassword from './Step/StepNewPassword';
@@ -27,6 +29,7 @@ function ModifyPasswordForm() {
     },
   });
   const watchFields = watch();
+  const showToast = CustomToast();
 
   // steps : oldPassword, newPassword
   const [step, setStep] = useState('oldPassword');
@@ -40,6 +43,7 @@ function ModifyPasswordForm() {
       const res = await authRequest.modifyPassword_submit(token, watchFields.password);
 
       console.log(res);
+      showToast('비밀번호가 변경되었습니다.');
       navigate('/user', {replace: true});
     } catch (error) {
       console.log(error);

--- a/src/components/Auth/Signup/SignupForm.tsx
+++ b/src/components/Auth/Signup/SignupForm.tsx
@@ -45,7 +45,7 @@ function SignupForm({signupStep, setSignupStep}: SignupFormProps) {
       const {email, password, image, nickname} = data;
       const profile = dirtyFields.image ? await s3Request.uploadImage(image as FileList) : undefined;
 
-      const res = await authRequest.signup_submit(email, password, profile.split('?')[0], nickname, code);
+      const res = await authRequest.signup_submit(email, password, profile?.split('?')[0], nickname, code);
       console.log(res);
 
       if (res.data.responseCode === 204) {

--- a/src/pages/Auth/Withdrawal/Withdrawal.tsx
+++ b/src/pages/Auth/Withdrawal/Withdrawal.tsx
@@ -113,6 +113,7 @@ function Withdrawal() {
           actionButton='탈퇴하기'
           isSmallSize={true}
           onClickAction={signout}
+          onClickCancelAction={() => navigate('/user/privacy')}
         />
       </main>
     </div>

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -128,6 +128,7 @@ export interface AlertModalProps {
   actionButton: string;
   isSmallSize: boolean;
   onClickAction?: () => void;
+  onClickCancelAction?: () => void;
 }
 
 export interface CandidateListProps {


### PR DESCRIPTION
## 개요
QA기반 이슈 해결

## 스크린샷
<!---- 권장 -->
  
## 주요 내용

- [x] split 에러 해결
- [x] 비밀번호 변경시 모달 추가
- [x] alert 컴포넌트에 cancelAction 추가

## 고민한 점, 질문거리

발행된 이슈 연결 후 머지 후 자동 클로즈, 브랜치 삭제 연결
